### PR TITLE
Feature/refactored turn indicator

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,30 +1,11 @@
 import pygame
 from models.board import Board
 from constants.types import PAWN, ROOK
+from constants.colors import *
 
 pygame.init()
 
 pygame.init()
-
-
-def prepare_player_turn_indicator(board, screen, font, x, y):
-    text = "Vez das peças "
-    text += "brancas" if board.turn == 0 else "pretas"
-    indicator = font.render(text, True, (255, 255, 255))
-
-    screen_width = screen.get_width() / 2
-    text_width = indicator.get_width() / 2
-    x = screen_width - text_width
-
-    screen.blit(indicator, (x, y))
-
-
-def draw_button(screen, text, height, width, x, y):
-    text_font = pygame.font.Font(pygame.font.get_default_font(), int(height * 0.8))
-    pygame.draw.rect(screen, (210, 210, 210), (x, y, width, height), 0, 3, 3, 3, 3)
-    textButton = text_font.render(text, True, (0, 0, 0))
-    screen.blit(textButton, (x + ((width - textButton.get_width()) / 2), y + height * 0.2))
-
 
 def main():
     screen = pygame.display.set_mode([400, 500])
@@ -32,9 +13,6 @@ def main():
     pygame.display.flip()
     clock = pygame.time.Clock()
     buttonTextStart = "Iniciar/Abandonar"
-
-    # defining Text font
-    text_font = pygame.font.Font(pygame.font.get_default_font(), 20)
 
     # defining Text font
     text_font = pygame.font.Font(pygame.font.get_default_font(), 20)
@@ -56,13 +34,13 @@ def main():
                 elif restart_button_click_manager(pygame.mouse, screen):
                     board.prepare_board()
 
-        prepare_player_turn_indicator(board, screen, text_font, 100, 410)
+        
 
         draw_button(screen, buttonTextStart, 25, 200, screen.get_width() / 4, 440)
 
         pygame.display.update()
         clock.tick(60)
-        board.draw(screen)
+        board.draw(screen,text_font)
 
 
 def movement_manager(board):
@@ -89,6 +67,7 @@ def movement_manager(board):
 
                 candidate_house.set_piece(selected_house.get_piece())
                 selected_house.set_piece(None)
+                board.switch_turn()
 
         # lógica de alteração da peça selecionada
         board.unselect_selected_house()
@@ -100,14 +79,17 @@ def movement_manager(board):
     ]
 
     # verifica se há uma peça na casa
+    
     if not selected_house.get_piece() is None:
         selected_piece = selected_house.get_piece()
-        possible_moves = selected_piece.get_possible_moves(board)
+        if selected_piece.get_color() == board.get_turn():
+            possible_moves = selected_piece.get_possible_moves(board)
 
-        for possible_move in possible_moves:
-            board.houses[possible_move[0]][possible_move[1]].set_is_high_light(True)
+            for possible_move in possible_moves:
+                board.houses[possible_move[0]][possible_move[1]].set_is_high_light(True)
 
-        selected_piece.set_selected(True)
+            selected_piece.set_selected(True)
+            
 
 
 def restart_button_click_manager(mouse, screen):
@@ -115,27 +97,6 @@ def restart_button_click_manager(mouse, screen):
         0] <= screen.get_width() / 4 + 200 and
             mouse.get_pos()[1] >= 440 and mouse.get_pos()[
                 1] <= 440 + 25)
-
-
-def prepare_player_turn_indicator(board, screen, font, x, y):
-    text = "Vez das peças "
-    text += "brancas" if board.turn == 0 else "pretas"
-    indicator = font.render(text, True, (255, 255, 255))
-
-    screen_width = screen.get_width() / 2
-    text_width = indicator.get_width() / 2
-    x = screen_width - text_width
-
-    screen.blit(indicator, (x, y))
-
-
-def draw_button(screen, text, height, width, x, y):
-    text_font = pygame.font.Font(pygame.font.get_default_font(), int(height * 0.8))
-    pygame.draw.rect(screen, (210, 210, 210), (x, y, width, height), 0, 3, 3, 3, 3)
-    textButton = text_font.render(text, True, (0, 0, 0))
-    screen.blit(
-        textButton, (x + ((width - textButton.get_width()) / 2), y + height * 0.2)
-    )
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -12,13 +12,9 @@ def main():
     pygame.display.set_caption("Xadrez")
     pygame.display.flip()
     clock = pygame.time.Clock()
-    buttonTextStart = "Iniciar/Abandonar"
 
     # defining Text font
     text_font = pygame.font.Font(pygame.font.get_default_font(), 20)
-
-    # defining button text
-    buttonTextStart = "Iniciar/Abandonar"
 
     board = Board()
 
@@ -33,10 +29,6 @@ def main():
                     movement_manager(board)
                 elif restart_button_click_manager(pygame.mouse, screen):
                     board.prepare_board()
-
-        
-
-        draw_button(screen, buttonTextStart, 25, 200, screen.get_width() / 4, 440)
 
         pygame.display.update()
         clock.tick(60)

--- a/models/board.py
+++ b/models/board.py
@@ -107,9 +107,15 @@ class Board:
             
     def prepare_player_turn_indicator(self, screen, font, x, y):
         self.clean_turn_indicator(screen)
+        self.draw_button(screen,font)
         text = "Vez das peças "
-        text += "brancas" if self.turn == WHITE else "pretas"
-        indicator = font.render(text, True, (255, 255, 255))
+        if self.turn == WHITE:
+            text += "brancas"
+            color = WHITE
+        else:
+            text += "pretas"
+            color = (0, 0, 0)
+        indicator = font.render(text, True, color)
 
         screen_width = screen.get_width() / 2
         text_width = indicator.get_width() / 2
@@ -118,15 +124,20 @@ class Board:
         screen.blit(indicator, (x, y))
         
     def clean_turn_indicator(self, screen):
-        pygame.draw.rect(screen, (0, 0, 0), (0, 400, 400, 100))
+        pygame.draw.rect(screen, (26,120,122), (0, 400, 400, 100))
         
-    def draw_button(screen, text, height, width, x, y):
-    text_font = pygame.font.Font(pygame.font.get_default_font(), int(height * 0.8))
-    pygame.draw.rect(screen, (210, 210, 210), (x, y, width, height), 0, 3, 3, 3, 3)
-    textButton = text_font.render(text, True, (0, 0, 0))
-    screen.blit(
-        textButton, (x + ((width - textButton.get_width()) / 2), y + height * 0.2)
-    )
+    def draw_button(self, screen, font):
+        height = 25
+        width = 200
+        x = screen.get_width() / 4
+        y = 440
+        text = "Reiniciar Partida"
+        
+        pygame.draw.rect(screen, (210, 210, 210), (x, y, width, height ), 0, 3, 3, 3, 3)
+        textButton = font.render(text, True, (0, 0, 0))
+        screen.blit(
+            textButton, (x + ((width - textButton.get_width()) / 2), y + height * 0.2)
+        )
       
     def set_up_pieces(self):
         self.houses[0][0].set_piece(

--- a/models/board.py
+++ b/models/board.py
@@ -1,3 +1,4 @@
+import pygame
 from models.house import House
 from constants.colors import *
 
@@ -10,13 +11,12 @@ from models.pawn import Pawn
 
 from constants import images
 
-
 class Board:
     def __init__(self):
         self.prepare_board()
 
     def prepare_board(self):
-        self.turn = 0
+        self.turn = WHITE
         self.winner = None
         self.houses = self.build_houses()
         self.set_up_pieces()
@@ -34,7 +34,8 @@ class Board:
         selected_house.get_piece().set_selected(False)
 
 
-    def draw(self, display):
+    def draw(self, display, text_font):
+        self.prepare_player_turn_indicator(display, text_font, 100, 410)
         for col in range(0, 8):
             for row in range(0, 8):
                 self.houses[col][row].draw(display)
@@ -94,105 +95,136 @@ class Board:
         if self.get_house(pos).get_piece() == None:
             return False
         return my_color == self.get_house(pos).get_piece().get_color()
+    
+    def get_turn(self):
+        return self.turn
+    
+    def switch_turn(self):
+        if self.turn == WHITE:
+            self.turn = BLACK
+        else:
+            self.turn = WHITE
+            
+    def prepare_player_turn_indicator(self, screen, font, x, y):
+        self.clean_turn_indicator(screen)
+        text = "Vez das peças "
+        text += "brancas" if self.turn == WHITE else "pretas"
+        indicator = font.render(text, True, (255, 255, 255))
 
+        screen_width = screen.get_width() / 2
+        text_width = indicator.get_width() / 2
+        x = screen_width - text_width
+
+        screen.blit(indicator, (x, y))
+        
+    def clean_turn_indicator(self, screen):
+        pygame.draw.rect(screen, (0, 0, 0), (0, 400, 400, 100))
+        
+    def draw_button(screen, text, height, width, x, y):
+    text_font = pygame.font.Font(pygame.font.get_default_font(), int(height * 0.8))
+    pygame.draw.rect(screen, (210, 210, 210), (x, y, width, height), 0, 3, 3, 3, 3)
+    textButton = text_font.render(text, True, (0, 0, 0))
+    screen.blit(
+        textButton, (x + ((width - textButton.get_width()) / 2), y + height * 0.2)
+    )
       
     def set_up_pieces(self):
         self.houses[0][0].set_piece(
-            Rook(0, 0, "black", images.black_rook, self.houses[0][0])
+            Rook(0, 0, BLACK, images.black_rook, self.houses[0][0])
         )
         self.houses[1][0].set_piece(
-            Horse(1, 0, "black", images.black_horse, self.houses[1][0])
+            Horse(1, 0, BLACK, images.black_horse, self.houses[1][0])
         )
         self.houses[2][0].set_piece(
-            Bishop(2, 0, "black", images.black_bishop, self.houses[2][0])
+            Bishop(2, 0, BLACK, images.black_bishop, self.houses[2][0])
         )
         self.houses[3][0].set_piece(
-            Queen(3, 0, "black", images.black_queen, self.houses[3][0])
+            Queen(3, 0, BLACK, images.black_queen, self.houses[3][0])
         )
         self.houses[4][0].set_piece(
-            King(4, 0, "black", images.black_king, self.houses[4][0])
+            King(4, 0, BLACK, images.black_king, self.houses[4][0])
         )
         self.houses[5][0].set_piece(
-            Bishop(5, 0, "black", images.black_bishop, self.houses[5][0])
+            Bishop(5, 0, BLACK, images.black_bishop, self.houses[5][0])
         )
         self.houses[6][0].set_piece(
-            Horse(6, 0, "black", images.black_horse, self.houses[6][0])
+            Horse(6, 0, BLACK, images.black_horse, self.houses[6][0])
         )
         self.houses[7][0].set_piece(
-            Rook(7, 0, "black", images.black_rook, self.houses[7][0])
+            Rook(7, 0, BLACK, images.black_rook, self.houses[7][0])
         )
 
         self.houses[0][1].set_piece(
-            Pawn(0, 1, "black", images.black_pawn, self.houses[0][1])
+            Pawn(0, 1, BLACK, images.black_pawn, self.houses[0][1])
         )
         self.houses[1][1].set_piece(
-            Pawn(1, 1, "black", images.black_pawn, self.houses[1][1])
+            Pawn(1, 1, BLACK, images.black_pawn, self.houses[1][1])
         )
         self.houses[2][1].set_piece(
-            Pawn(2, 1, "black", images.black_pawn, self.houses[2][1])
+            Pawn(2, 1, BLACK, images.black_pawn, self.houses[2][1])
         )
         self.houses[3][1].set_piece(
-            Pawn(3, 1, "black", images.black_pawn, self.houses[3][1])
+            Pawn(3, 1, BLACK, images.black_pawn, self.houses[3][1])
         )
         self.houses[4][1].set_piece(
-            Pawn(4, 1, "black", images.black_pawn, self.houses[4][1])
+            Pawn(4, 1, BLACK, images.black_pawn, self.houses[4][1])
         )
         self.houses[5][1].set_piece(
-            Pawn(5, 1, "black", images.black_pawn, self.houses[5][1])
+            Pawn(5, 1, BLACK, images.black_pawn, self.houses[5][1])
         )
         self.houses[6][1].set_piece(
-            Pawn(6, 1, "black", images.black_pawn, self.houses[6][1])
+            Pawn(6, 1, BLACK, images.black_pawn, self.houses[6][1])
         )
         self.houses[7][1].set_piece(
-            Pawn(7, 1, "black", images.black_pawn, self.houses[7][1])
+            Pawn(7, 1, BLACK, images.black_pawn, self.houses[7][1])
         )
 
         self.houses[0][7].set_piece(
-            Rook(0, 7, "white", images.white_rook, self.houses[0][7])
+            Rook(0, 7, WHITE, images.white_rook, self.houses[0][7])
         )
         self.houses[1][7].set_piece(
-            Horse(1, 7, "white", images.white_horse, self.houses[1][7])
+            Horse(1, 7, WHITE, images.white_horse, self.houses[1][7])
         )
         self.houses[2][7].set_piece(
-            Bishop(2, 7, "white", images.white_bishop, self.houses[2][7])
+            Bishop(2, 7, WHITE, images.white_bishop, self.houses[2][7])
         )
         self.houses[3][7].set_piece(
-            Queen(3, 7, "white", images.white_queen, self.houses[3][7])
+            Queen(3, 7, WHITE, images.white_queen, self.houses[3][7])
         )
         self.houses[4][7].set_piece(
-            King(4, 7, "white", images.white_king, self.houses[4][7])
+            King(4, 7, WHITE, images.white_king, self.houses[4][7])
         )
         self.houses[5][7].set_piece(
-            Bishop(5, 7, "white", images.white_bishop, self.houses[5][7])
+            Bishop(5, 7, WHITE, images.white_bishop, self.houses[5][7])
         )
         self.houses[6][7].set_piece(
-            Horse(6, 7, "white", images.white_horse, self.houses[6][7])
+            Horse(6, 7, WHITE, images.white_horse, self.houses[6][7])
         )
         self.houses[7][7].set_piece(
-            Rook(7, 7, "white", images.white_rook, self.houses[7][7])
+            Rook(7, 7, WHITE, images.white_rook, self.houses[7][7])
         )
 
         self.houses[0][6].set_piece(
-            Pawn(0, 6, "white", images.white_pawn, self.houses[0][6])
+            Pawn(0, 6, WHITE, images.white_pawn, self.houses[0][6])
         )
         self.houses[1][6].set_piece(
-            Pawn(1, 6, "white", images.white_pawn, self.houses[1][6])
+            Pawn(1, 6, WHITE, images.white_pawn, self.houses[1][6])
         )
         self.houses[2][6].set_piece(
-            Pawn(2, 6, "white", images.white_pawn, self.houses[2][6])
+            Pawn(2, 6, WHITE, images.white_pawn, self.houses[2][6])
         )
         self.houses[3][6].set_piece(
-            Pawn(3, 6, "white", images.white_pawn, self.houses[3][6])
+            Pawn(3, 6, WHITE, images.white_pawn, self.houses[3][6])
         )
         self.houses[4][6].set_piece(
-            Pawn(4, 6, "white", images.white_pawn, self.houses[4][6])
+            Pawn(4, 6, WHITE, images.white_pawn, self.houses[4][6])
         )
         self.houses[5][6].set_piece(
-            Pawn(5, 6, "white", images.white_pawn, self.houses[5][6])
+            Pawn(5, 6, WHITE, images.white_pawn, self.houses[5][6])
         )
         self.houses[6][6].set_piece(
-            Pawn(6, 6, "white", images.white_pawn, self.houses[6][6])
+            Pawn(6, 6, WHITE, images.white_pawn, self.houses[6][6])
         )
         self.houses[7][6].set_piece(
-            Pawn(7, 6, "white", images.white_pawn, self.houses[7][6])
+            Pawn(7, 6, WHITE, images.white_pawn, self.houses[7][6])
         )

--- a/models/pawn.py
+++ b/models/pawn.py
@@ -1,6 +1,7 @@
 from models.piece import Piece
 from util.move import *
 from constants.types import PAWN
+from constants.colors import *
 
 
 class Pawn(Piece):
@@ -23,11 +24,10 @@ class Pawn(Piece):
     def update_possible_moves(self, board):
         self.move_list = []
         pos = self.house.get_position()
-        if self.get_color() == 'white':
+        if self.get_color() == WHITE:
             pawn_move = up
             diag_right_house = up_right(pos)
             diag_left_house = up_left(pos)
-        # elif self.get_color() == 'black'
         else:
             pawn_move = down
             diag_right_house = down_right(pos)

--- a/models/piece.py
+++ b/models/piece.py
@@ -1,5 +1,5 @@
 import pygame
-
+from constants.colors import *
 
 class Piece(object):
     def __init__(self, col, row, color, img, house):
@@ -19,7 +19,7 @@ class Piece(object):
 
     def draw(self, windows, x, y):
 
-        draw_this = pygame.transform.scale(self.img, (27, 27)) if self.color == "white" \
+        draw_this = pygame.transform.scale(self.img, (27, 27)) if self.color == WHITE \
             else pygame.transform.scale(self.img, (27, 27))
 
         if self.selected:


### PR DESCRIPTION
Adicionei o métodos para troca de turno para atualizar o turno e só deixar jogar as peças do turno.
E reposicionei os metodos de desenho do console e do botão do main.py para board.py afim de atualizar junto com o tabuleiro.
Alterada a cor do texto do turno conforme o turno selecionado.
![vez_branca](https://user-images.githubusercontent.com/32250493/111874581-b9b83180-8974-11eb-96de-6621b9a352ca.png)
![vez_pretas](https://user-images.githubusercontent.com/32250493/111874583-bb81f500-8974-11eb-94b1-84e8907f9b13.png)

