### PR TITLE
Bug do contador de peças capturadas resolvido

### DIFF
--- a/models/match.py
+++ b/models/match.py
@@ -149,17 +149,16 @@ class Match:
                 
                 
                 self.checked = self.is_checked(self.get_turn())
-                
-                if not self.checked:
-                    if (captured_piece is not None and selected_piece.get_color() == WHITE):
-                        self.whiteCapturePieceIncator += 1
-                    elif (captured_piece is not None and selected_piece.get_color() == BLACK):
-                        self.blackCapturePieceIncator += 1
 
                 if self.checked:
                     self.undo_move(selected_house, desired_house, captured_piece)
 
                 else:
+                    if (captured_piece is not None and selected_piece.get_color() == WHITE):
+                        self.whiteCapturePieceIncator += 1
+                    elif (captured_piece is not None and selected_piece.get_color() == BLACK):
+                        self.blackCapturePieceIncator += 1
+                        
                     # promocao do peao
                     if selected_piece.get_type() == PAWN and selected_piece.can_be_promoted():
                         if selected_piece.get_color() == BLACK:

--- a/models/match.py
+++ b/models/match.py
@@ -146,13 +146,16 @@ class Match:
                 
                 # lógica de movimentação e captura
                 captured_piece = self.move(selected_house, desired_house)
-
-                if (captured_piece is not None and selected_piece.get_color() == WHITE):
-                    self.whiteCapturePieceIncator += 1
-                elif (captured_piece is not None and selected_piece.get_color() == BLACK):
-                    self.blackCapturePieceIncator += 1
-
+                
+                
                 self.checked = self.is_checked(self.get_turn())
+                
+                if not self.checked:
+                    if (captured_piece is not None and selected_piece.get_color() == WHITE):
+                        self.whiteCapturePieceIncator += 1
+                    elif (captured_piece is not None and selected_piece.get_color() == BLACK):
+                        self.blackCapturePieceIncator += 1
+
                 if self.checked:
                     self.undo_move(selected_house, desired_house, captured_piece)
 


### PR DESCRIPTION
Quando o jogador fazia um movimento de captura inválido, o contador era incrementado. Agora é feita uma verificação se o movimento é válido ou não para fazer o incremento do contador